### PR TITLE
Only run PyPI upload step if repo is not a fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
     name: Upload to PyPI
     needs: [build-wheels, build-sdist, test-sdist]
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'dokempf'
 
     steps:
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Forks don't have access to the API key for uploading to PyPI, making the step fail.