### PR TITLE
Use py2.py3 for bdist platform tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,6 @@ jobs:
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
 
-    - name: Rename wheels to work with all Python3
-      shell: python
-      run: |
-        import glob
-        import shutil
-        for wheel in glob.glob("wheelhouse/*.whl"):
-            parts = wheel.split("-")
-            parts[2] = "py3"
-            parts[3] = "none"
-            newwheel = "-".join(parts)
-            shutil.move(wheel, newwheel)
-
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,18 @@
+
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from skbuild import setup
 
 import re
 
+class genericpy_bdist_wheel(_bdist_wheel):
+    def finalize_options(self):
+        _bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        python, abi, plat = _bdist_wheel.get_tag(self)
+        python, abi = "py2.py3", "none"
+        return python, abi, plat
 
 # Read the clang-format version from the "single source of truth"
 def get_version():
@@ -17,10 +28,11 @@ def get_version():
 with open("README.md", "r") as readme_file:
     readme = readme_file.read()
 
-
+cmdclass = {"bdist_wheel": genericpy_bdist_wheel}
 setup(
     name="clang-format",
     version="0.0.7",
+    cmdclass=cmdclass,
     author="Dominic Kempf",
     author_email="ssc@iwr.uni-heidelberg.de",
     packages=["clang_format"],


### PR DESCRIPTION
Changes the binary wheel platform tag to py2.py3 to match the existing clang-format wheel (there shouldn't be anything preventing it from working on py2, though people really should update).

Also switched from the wheel renaming step in the workflow to a bdist class that reports the "correct" platform tag. This should make so other users building packages should also get the generic python tags, such as the automated builds for Raspberry PI done by https://www.piwheels.org/