### PR TITLE
Make test-sdist step depend on build-sdist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
   
   test-sdist:
     name: Test build from source distribution
+    needs: [build-sdist]
     runs-on: ubuntu-20.04
 
     steps:
@@ -105,7 +106,8 @@ jobs:
           path: sdist
 
       - name: Install from SDist
-        run: pip install sdist/*.tar.gz
+        run:
+          pip install sdist/*.tar.gz
 
       - name: Install test requirements
         run:


### PR DESCRIPTION
Adds `build-sdist` as a `needs` dependency to the `test-sdist` step in the GitHub Actions Workflow -- otherwise the sdist file isn't found for testing.

Here's a run with the change: https://github.com/nightlark/clang-format-wheel/actions/runs/1130757240