### PR TITLE
Add option to skip running qemu builds in GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,17 @@ name: Build + Release Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      use_qemu:
+        description: "Use qemu for builds with targets requiring emulation"
+        required: true
+        default: true
   release:
     types:
       - published
+
+env:
+  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu) }} || (github.event_name == 'published')
 
 jobs:
   build-wheels:
@@ -16,43 +24,55 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: "x86_64"
+            use_qemu: false
           - os: ubuntu-20.04
             arch: "i686"
+            use_qemu: false
           - os: ubuntu-20.04
             arch: "aarch64"
+            use_qemu: true
           - os: ubuntu-20.04
             arch: "ppc64le"
+            use_qemu: true
           - os: ubuntu-20.04
             arch: "s390x"
+            use_qemu: true
           - os: windows-2016
             arch: "AMD64"
+            use_qemu: false
           - os: windows-2016
             arch: "x86"
+            use_qemu: false
           - os: macos-10.15
             arch: "universal2"
+            use_qemu: false
 
     steps:
     - uses: actions/checkout@v2
+      if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
     
     - name: Support long paths
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && ((!matrix.use_qemu) || fromJSON(env.USE_QEMU))
       run: git config --system core.longpaths true
 
     - uses: actions/setup-python@v2
       name: Install Python
+      if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
       with:
         python-version: '3.8'
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1.2.0
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && ((matrix.use_qemu) && fromJSON(env.USE_QEMU))
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.0.1
+      if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
 
     - uses: actions/upload-artifact@v2
+      if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
       with:
         path: ./wheelhouse/*.whl
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu) }} || (github.event_name == 'published')
+  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu) || 'false' }} || (github.event_name == 'published')
 
 jobs:
   build-wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu || 'false') || (github.event.action == 'published') }}
+  USE_QEMU: ${{ (github.event.inputs.use_qemu == 'true') || (github.event.action == 'published') }}
 
 jobs:
   build-wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu) || 'false' }} || (github.event_name == 'published')
+  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu || 'false') || (github.event_name == 'published') }}
 
 jobs:
   build-wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu || 'false') || (github.event_name == 'published') }}
+  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu || 'false') || (github.event.action == 'published') }}
 
 jobs:
   build-wheels:


### PR DESCRIPTION
Adds an option to skip running the qemu builds. Similar to the option in cmake-python-distributions but with some tweaks to the condition logic to handle `published` events instead of tags and treats any input for `skip_qemu` other than `true` as `false` (rather than completely failing the job if some random string is entered).