### PR TITLE
ci: minor cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,13 @@ jobs:
     - name: Support long paths
       if: runner.os == 'Windows'
       run: git config --system core.longpaths true
-
-    - uses: actions/setup-python@v2
-      name: Install Python
-      with:
-        python-version: '3.8'
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1.2.0
       if: runner.os == 'Linux'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.0.1
+      uses: pypa/cibuildwheel@v2.1.2
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
 
@@ -62,11 +57,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.8'
 
       - name: Build SDist
         run: pipx run build --sdist
@@ -86,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
These are a few minor bits of cleanup. Several setup-python actions had no effect; they were never used later, confusing the reader, complicating #4, and taking extra time. Also bumped the version of cibuildwheel. Finally, I moved the test version of Python to 3.9, just so that the build Python (3.8) and the test Python versions avoid matching, just in case it every surfaces a cross-compatibility issue.