### PR TITLE
Override LLVM version in GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Build + Release Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      llvm_version:
+        description: "LLVM version to build"
+        required: false
+        default: ""
   release:
     types:
       - published
@@ -42,6 +47,10 @@ jobs:
       name: Install Python
       with:
         python-version: '3.8'
+
+    - name: Override LLVM version
+      if: github.event.inputs.llvm_version
+      run: echo "set(CLANG_FORMAT_VERSION ${{ github.event.inputs.llvm_version }})" > clang-format_version.cmake
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,10 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Override LLVM version
+        if: github.event.inputs.llvm_version
+        run: echo "set(CLANG_FORMAT_VERSION ${{ github.event.inputs.llvm_version }})" > clang-format_version.cmake
+ 
       - name: Build SDist
         run: pipx run build --sdist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: '3.8'
 
-    - name: Override LLVM version
+    - name: Override LLVM version (${{ github.event.inputs.llvm_version }})
       if: github.event.inputs.llvm_version
       run: echo "set(CLANG_FORMAT_VERSION ${{ github.event.inputs.llvm_version }})" > clang-format_version.cmake
     
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Override LLVM version
+      - name: Override LLVM version (${{ github.event.inputs.llvm_version }})
         if: github.event.inputs.llvm_version
         run: echo "set(CLANG_FORMAT_VERSION ${{ github.event.inputs.llvm_version }})" > clang-format_version.cmake
  


### PR DESCRIPTION
Adds an option to override the LLVM version pulled and built as part of a GHA workflow run.